### PR TITLE
Anchore Action - fail build - true/false behavior testing

### DIFF
--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -12,7 +12,7 @@ jobs:
       id: scan
       with:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
-        fail-build: true
+        #fail-build: true
         
     - name: upload Anchore scan SARIF report
       if: always()

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -12,7 +12,7 @@ jobs:
       id: scan
       with:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
-        #fail-build: true
+        fail-build: false
         
     - name: upload Anchore scan SARIF report
       if: always()

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -12,19 +12,22 @@ jobs:
       id: scan
       with:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
-        fail-build: false
+        fail-build: true
         
     - name: upload Anchore scan SARIF report
-      uses: github/codeql-action/upload-sarif@v1
+      if: always()
+      uses: github/codeql-action/upload-sarif@v2
       with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
 #Optionally, you can add a step to inspect the SARIF report produced:
     - name: Inspect action SARIF report
+      if: always()
       run: cat ${{ steps.scan.outputs.sarif }}
     
-    - name: AnalyzeES
-      uses: Azure/container-scan@v0.1
-      with:
-        image-name: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
-        continue-on-error: true
+    # Dockle/Trivy Azure Scan is Depreceated
+    #- name: AnalyzeES
+    #  uses: Azure/container-scan@v0.1
+    #  with:
+    #    image-name: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
+    #    continue-on-error: true


### PR DESCRIPTION
# Default/fail-build: true
- NOTE: this would fail PR workflows even when old security findings are re-discovered in every new PR
![image](https://user-images.githubusercontent.com/1760475/198296769-859ea24b-1b8c-41e8-8892-f3c726d93a39.png)
![image](https://user-images.githubusercontent.com/1760475/198296898-337a5f98-4b60-4695-a141-92e0bf478e04.png)

# fail-build: false
- Use this in combination with [Settings > Security > Code security and analysis > Check Failure section](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#defining-the-severities-causing-pull-request-check-failure) to fail a workflow
![image](https://user-images.githubusercontent.com/1760475/198298181-0a0d8f57-dfb0-4679-a7ad-4c389214f808.png)
![image](https://user-images.githubusercontent.com/1760475/198298298-8d7a40ee-29af-408c-8567-9cba3a887139.png)

