### PR TITLE
Sarif Command Line Output (sarif-fmt)

### DIFF
--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -34,7 +34,8 @@ jobs:
 #Optionally, you can add a step to inspect the SARIF report produced:
     - name: Inspect action SARIF report
       run: cat ${{ steps.scan.outputs.sarif }}
-    
+
+# Deprecated - Use Trivy and Dockle separately
 #    - name: AnalyzeES
 #      uses: Azure/container-scan@v0.1
 #      with:

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -23,6 +23,12 @@ jobs:
       with:        
         name: sarif-results
         path: ${{ steps.scan.outputs.sarif }}
+        
+    - name: pretty print sarif via https://lib.rs/crates/sarif-fmt
+      run: |
+        cargo install sarif-fmt
+        cat ${{ steps.scan.outputs.sarif }} | sarif-fmt
+
 
 #Optionally, you can add a step to inspect the SARIF report produced:
     - name: Inspect action SARIF report

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -26,7 +26,8 @@ jobs:
         
     - name: pretty print sarif via https://lib.rs/crates/sarif-fmt
       run: |
-        cargo binstall sarif-fmt
+        #cargo install sarif-fmt
+        curl -sSL https://github.com/psastras/sarif-rs/releases/download/sarif-fmt-latest/sarif-fmt-x86_64-unknown-linux-gnu -o sarif-fmt
         cat ${{ steps.scan.outputs.sarif }} | sarif-fmt
 
 

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -19,12 +19,17 @@ jobs:
       with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
+    - uses: actions/upload-artifact@v3
+      with:        
+        name: sarif-results
+        path: ${{ steps.scan.outputs.sarif }}
+
 #Optionally, you can add a step to inspect the SARIF report produced:
     - name: Inspect action SARIF report
       run: cat ${{ steps.scan.outputs.sarif }}
     
-    - name: AnalyzeES
-      uses: Azure/container-scan@v0.1
-      with:
-        image-name: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
-        continue-on-error: true
+#    - name: AnalyzeES
+#      uses: Azure/container-scan@v0.1
+#      with:
+#        image-name: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
+#        continue-on-error: true

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -26,7 +26,7 @@ jobs:
         
     - name: pretty print sarif via https://lib.rs/crates/sarif-fmt
       run: |
-        cargo bininstall sarif-fmt
+        cargo binstall sarif-fmt
         cat ${{ steps.scan.outputs.sarif }} | sarif-fmt
 
 

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -26,7 +26,7 @@ jobs:
         
     - name: pretty print sarif via https://lib.rs/crates/sarif-fmt
       run: |
-        cargo install sarif-fmt
+        cargo bininstall sarif-fmt
         cat ${{ steps.scan.outputs.sarif }} | sarif-fmt
 
 


### PR DESCRIPTION
[sarif-fmt](https://lib.rs/crates/sarif-fmt) Tool
- [Workflow Output](https://github.com/vulna-felickz/log4shell-vulnerable-app/actions/runs/3372497920/jobs/5595997174#step:6:1225): 
```
warning: The path /usr/share/elasticsearch/modules/x-pack-core/netty-codec-http-4.1.49.Final.jar reports netty-codec-http at version 4.1.49.Final  which is a vulnerable (java-archive) package installed in the container

warning: 552 warnings emitted
```